### PR TITLE
Fixed the wrong type of method params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 declare type PropertiesType = string | number | boolean | Array<string>;
 
+declare type PropertiesObjectType = { [key: string]: PropertiesType }
+
 declare module 'sensorsdata-analytics-react-native'{
 
   /**
@@ -18,16 +20,15 @@ declare module 'sensorsdata-analytics-react-native'{
    * 设置用户属性
    *
    * @param profile 用户属性
-
    */
-   export function profileSet(profile: Map<string,PropertiesType>): void
+   export function profileSet(profile: PropertiesObjectType): void
 
   /**
    * 记录初次设定的属性
    *
    * @param profile 用户属性
    */
-   export function profileSetOnce(profile: Map<string,PropertiesType>): void
+   export function profileSetOnce(profile: PropertiesObjectType): void
 
   /**
    * 追踪事件
@@ -35,7 +36,7 @@ declare module 'sensorsdata-analytics-react-native'{
    * @param event 事件名称
    * @param properties 事件属性
    */
-   export function track(event: string, properties?: Map<string,PropertiesType> | null): void;
+   export function track(event: string, properties?: PropertiesObjectType | null): void;
 
   /**
    * 事件开始
@@ -50,7 +51,7 @@ declare module 'sensorsdata-analytics-react-native'{
    * @param event 事件名称
    * @param properties 事件属性
    */
-   export function trackTimerEnd(event: string, properties?: Map<string,PropertiesType> | null): void;
+   export function trackTimerEnd(event: string, properties?: PropertiesObjectType | null): void;
 
   /**
    * 清除所有事件计时器
@@ -63,7 +64,7 @@ declare module 'sensorsdata-analytics-react-native'{
    * @param eventName 事件名称
    * @param properties 事件属性
    */
-   export function trackInstallation(eventName: string, properties?: Map<string,PropertiesType> | null): void;
+   export function trackInstallation(eventName: string, properties?: PropertiesObjectType | null): void;
 
   /**
    * 切换页面的时候调用，用于记录 $AppViewScreen 事件..
@@ -71,7 +72,7 @@ declare module 'sensorsdata-analytics-react-native'{
    * @param url 页面 url
    * @param properties 事件属性
    */
-   export function trackViewScreen(url: string, properties?: Map<string,PropertiesType> | null): void;
+   export function trackViewScreen(url: string, properties?: PropertiesObjectType | null): void;
 
   /**
    * 给一个数值类型的 Profile 增加一个数值. 只能对数值型属性进行操作，若该属性
@@ -117,7 +118,7 @@ declare module 'sensorsdata-analytics-react-native'{
    *
    * @param properties 公共属性
    */
-   export function registerSuperProperties(properties:Map<string,PropertiesType>): void;
+   export function registerSuperProperties(properties: PropertiesObjectType): void;
 
   /**
    * 删除某个公共属性
@@ -142,7 +143,6 @@ declare module 'sensorsdata-analytics-react-native'{
    export function deleteAll(): void;
 
   /**
-
   /**
    * 替换“匿名 ID”
    *
@@ -203,7 +203,7 @@ declare module 'sensorsdata-analytics-react-native'{
    * @param itemId item ID
    * @param properties item 相关属性
    */
-   export function itemSet(itemType: string, itemId: string, properties: Map<string,PropertiesType> | null): void;
+   export function itemSet(itemType: string, itemId: string, properties: PropertiesObjectType | null): void;
 
   /**
    * 删除 item
@@ -216,12 +216,12 @@ declare module 'sensorsdata-analytics-react-native'{
   /**
    * 获取事件公共属性
    */
-   export function getSuperPropertiesPromise(): Promise<Map<string,PropertiesType>>;
+   export function getSuperPropertiesPromise(): Promise<PropertiesObjectType>;
 
   /**
    * 返回预置属性
    */
-   export function getPresetPropertiesPromise(): Promise<Map<string,PropertiesType>>;
+   export function getPresetPropertiesPromise(): Promise<PropertiesObjectType>;
 
   /**
    * 获取当前用户的 loginId 若调用前未调用 {@link #login(String)} 设置用户的 loginId，会返回 null
@@ -271,7 +271,7 @@ declare module 'sensorsdata-analytics-react-native'{
    *
    * @param properties 渠道追踪事件的属性
    */
-   export function trackAppInstall(properties: Map<string,PropertiesType> | null)
+   export function trackAppInstall(properties: PropertiesObjectType | null)
 
   /************** Android only start *****************/
   /**
@@ -316,4 +316,3 @@ declare module 'sensorsdata-analytics-react-native'{
 
   /************** Android only end *****************/
 }
-


### PR DESCRIPTION
当前 index.d.ts 中定义的 properties 参数类型时 Map，实际中如果按 Map 传过去的话原生接收不到传过去的值，而按 Object 传过去的话原生是能拿到这个值的。
以 Android 为例，原生方法 Java 的 ReadableMap 参数类型对应到 JavaScript 的类型时 Object。
参考链接：https://reactnative.dev/docs/native-modules-android#argument-types